### PR TITLE
java.lang.IllegalAccessException: class com.sun.jna.Structure (in module com.sun.jna) cannot access class com.microsoft.credentialstorage.implementation.windows.CredAdvapi32$PCREDENTIAL

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -12,4 +12,5 @@ module com.microsoft.credentialstorage {
     exports com.microsoft.credentialstorage.implementation.posix.internal to com.sun.jna;
     exports com.microsoft.credentialstorage.implementation.posix.keyring to com.sun.jna;
     exports com.microsoft.credentialstorage.implementation.posix.libsecret to com.sun.jna;
+    exports com.microsoft.credentialstorage.implementation.windows to com.sun.jna;
 }


### PR DESCRIPTION
```
Caused by: java.lang.Error: Exception reading field 'credential' in class com.microsoft.credentialstorage.implementation.windows.CredAdvapi32$PCREDENTIAL
	at com.sun.jna@5.9.0/com.sun.jna.Structure.getFieldValue(Structure.java:653)
	at com.sun.jna@5.9.0/com.sun.jna.Structure.deriveLayout(Structure.java:1318)
	at com.sun.jna@5.9.0/com.sun.jna.Structure.calculateSize(Structure.java:1192)
	at com.sun.jna@5.9.0/com.sun.jna.Structure.calculateSize(Structure.java:1144)
	at com.sun.jna@5.9.0/com.sun.jna.Structure.allocateMemory(Structure.java:426)
	at com.sun.jna@5.9.0/com.sun.jna.Structure.<init>(Structure.java:216)
	at com.sun.jna@5.9.0/com.sun.jna.Structure.<init>(Structure.java:204)
	at com.sun.jna@5.9.0/com.sun.jna.Structure.<init>(Structure.java:191)
	at com.sun.jna@5.9.0/com.sun.jna.Structure.<init>(Structure.java:183)
	at com.microsoft.credentialstorage@1.0.0/com.microsoft.credentialstorage.implementation.windows.CredAdvapi32$PCREDENTIAL.<init>(CredAdvapi32.java:304)
	at com.microsoft.credentialstorage@1.0.0/com.microsoft.credentialstorage.implementation.windows.CredManagerBackedSecureStore.readSecret(CredManagerBackedSecureStore.java:123)
	at com.microsoft.credentialstorage@1.0.0/com.microsoft.credentialstorage.implementation.windows.CredManagerBackedSecureStore.get(CredManagerBackedSecureStore.java:46)
	at com.xxx.xxx/com.xxx.xxx.view.settings.Configuration.load(Configuration.java:60)
	at com.xxx.xxx/com.xxx.xxx.view.settings.Configuration.getInstance(Configuration.java:45)
	at com.xxx.xxx/com.xxx.xxx.view.main.MainController.loadData(MainController.java:145)
	at com.xxx.xxx/com.xxx.xxx.view.main.MainController.initialize(MainController.java:73)
	... 24 more
Caused by: java.lang.IllegalAccessException: class com.sun.jna.Structure (in module com.sun.jna) cannot access class com.microsoft.credentialstorage.implementation.windows.CredAdvapi32$PCREDENTIAL (in module com.microsoft.credentialstorage) because module com.microsoft.credentialstorage does not export com.microsoft.credentialstorage.implementation.windows to module com.sun.jna
	at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:392)
	at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:674)
	at java.base/java.lang.reflect.Field.checkAccess(Field.java:1102)
	at java.base/java.lang.reflect.Field.get(Field.java:423)
	at com.sun.jna@5.9.0/com.sun.jna.Structure.getFieldValue(Structure.java:650)
	... 39 more
```