### PR TITLE
Handle properly non-ascii values in credentials

### DIFF
--- a/src/main/java/com/microsoft/credentialstorage/implementation/macosx/KeychainSecurityCliStore.java
+++ b/src/main/java/com/microsoft/credentialstorage/implementation/macosx/KeychainSecurityCliStore.java
@@ -26,7 +26,7 @@ public class KeychainSecurityCliStore {
     private static final String ACCOUNT_PARAMETER = "-a";
     private static final String SERVICE_PARAMETER = "-s";
     private static final String KIND_PARAMETER = "-D";
-    private static final String PASSWORD_PARAMETER = "-w";
+    private static final String PASSWORD_PARAMETER = "-X";
     private static final String UPDATE_IF_ALREADY_EXISTS = "-U";
     private static final int ITEM_NOT_FOUND_EXIT_CODE = 44;
     private static final int USER_INTERACTION_NOT_ALLOWED_EXIT_CODE = 36;
@@ -310,7 +310,7 @@ public class KeychainSecurityCliStore {
                 UPDATE_IF_ALREADY_EXISTS,
                 ACCOUNT_PARAMETER, accountName,
                 SERVICE_PARAMETER, serviceName,
-                PASSWORD_PARAMETER, password,
+                PASSWORD_PARAMETER, getHexString(password),
                 KIND_PARAMETER, secretKind.name()
             };
             final Process process = addProcessBuilder.start();
@@ -388,5 +388,16 @@ public class KeychainSecurityCliStore {
                     + Character.digit(hexString.charAt(i+1), 16));
         }
         return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    private static String getHexString(char[] input) {
+        StringBuilder hexString = new StringBuilder();
+
+        byte[] bytes = new String(input).getBytes(StandardCharsets.UTF_8);
+        for (byte b : bytes) {
+            hexString.append(Integer.toHexString(b & 0xFF));
+        }
+
+        return hexString.toString();
     }
 }

--- a/src/test/java/com/microsoft/credentialstorage/StorageProviderTest.java
+++ b/src/test/java/com/microsoft/credentialstorage/StorageProviderTest.java
@@ -3,15 +3,14 @@
 
 package com.microsoft.credentialstorage;
 
+import com.microsoft.credentialstorage.model.StoredCredential;
 import com.microsoft.credentialstorage.model.StoredToken;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class StorageProviderTest {
 
@@ -64,6 +63,21 @@ public class StorageProviderTest {
 
         final SecretStore<StoredToken> actual = StorageProvider.getStore(false, StorageProvider.SecureOption.PREFERRED, candidates, generator);
         assertFalse(actual.isSecure());
+    }
+
+    @Test
+    public void persisted_shouldStoreNonAscii() {
+        final String key = "NotExisting";
+
+        final SecretStore<StoredCredential> credentialStorage = StorageProvider.getCredentialStorage(true, StorageProvider.SecureOption.PREFERRED);
+        assertTrue(credentialStorage.isSecure());
+
+        StoredCredential credentialsToStore = new StoredCredential("TästUser", "TästPassword".toCharArray());
+        credentialStorage.add(key, credentialsToStore);
+
+        StoredCredential stored = credentialStorage.get(key);
+        assertEquals("TästUser", stored.getUsername());
+        assertEquals("TästPassword", new String(stored.getPassword()));
     }
 
     private SecretStore<StoredToken> getStore(final boolean secure) {

--- a/src/test/java/com/microsoft/credentialstorage/StorageProviderTest.java
+++ b/src/test/java/com/microsoft/credentialstorage/StorageProviderTest.java
@@ -3,7 +3,6 @@
 
 package com.microsoft.credentialstorage;
 
-import com.microsoft.credentialstorage.model.StoredCredential;
 import com.microsoft.credentialstorage.model.StoredToken;
 import org.junit.Test;
 
@@ -63,21 +62,6 @@ public class StorageProviderTest {
 
         final SecretStore<StoredToken> actual = StorageProvider.getStore(false, StorageProvider.SecureOption.PREFERRED, candidates, generator);
         assertFalse(actual.isSecure());
-    }
-
-    @Test
-    public void persisted_shouldStoreNonAscii() {
-        final String key = "NotExisting";
-
-        final SecretStore<StoredCredential> credentialStorage = StorageProvider.getCredentialStorage(true, StorageProvider.SecureOption.PREFERRED);
-        assertTrue(credentialStorage.isSecure());
-
-        StoredCredential credentialsToStore = new StoredCredential("TästUser", "TästPassword".toCharArray());
-        credentialStorage.add(key, credentialsToStore);
-
-        StoredCredential stored = credentialStorage.get(key);
-        assertEquals("TästUser", stored.getUsername());
-        assertEquals("TästPassword", new String(stored.getPassword()));
     }
 
     private SecretStore<StoredToken> getStore(final boolean secure) {

--- a/src/test/java/com/microsoft/credentialstorage/implementation/macosx/KeychainSecurityBackedCredentialStoreIT.java
+++ b/src/test/java/com/microsoft/credentialstorage/implementation/macosx/KeychainSecurityBackedCredentialStoreIT.java
@@ -85,4 +85,19 @@ public class KeychainSecurityBackedCredentialStoreIT {
         final StoredCredential nonExistent = underTest.get(key);
         assertNull("Credential can still be read from store", nonExistent);
     }
+
+    @Test
+    public void get_shouldHandleNonAsciiValues() {
+        final String key = "KeychainTest:http://test.com:Credential";
+
+        StoredCredential credential = new StoredCredential("TästUser", "\"TästPassword\"!@#$%^&*()-_=+{}[]:;\"'<>,.?/\\~`".toCharArray());
+        boolean success = underTest.add(key, credential);
+        assertTrue("Storing credential failed", success);
+
+        final StoredCredential readCred = underTest.get(key);
+
+        assertNotNull("Credential not found", readCred);
+        assertEquals("Retrieved Credential.Username is different", "TästUser", readCred.getUsername());
+        assertArrayEquals("Retrieved Credential.Password is different", "\"TästPassword\"!@#$%^&*()-_=+{}[]:;\"'<>,.?/\\~`".toCharArray(), readCred.getPassword());
+    }
 }

--- a/src/test/java/com/microsoft/credentialstorage/implementation/macosx/KeychainSecurityBackedTokenPairStoreIT.java
+++ b/src/test/java/com/microsoft/credentialstorage/implementation/macosx/KeychainSecurityBackedTokenPairStoreIT.java
@@ -7,11 +7,7 @@ import com.microsoft.credentialstorage.model.StoredTokenPair;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
 public class KeychainSecurityBackedTokenPairStoreIT {
@@ -50,5 +46,20 @@ public class KeychainSecurityBackedTokenPairStoreIT {
 
         StoredTokenPair nonExistent = underTest.get(key);
         assertNull("Token can still be read from store", nonExistent);
+    }
+
+    @Test
+    public void get_shouldHandleNonAsciiValues() {
+        final String key = "KeychainTest:http://test.com:TokenPair";
+
+        StoredTokenPair tokenPair = new StoredTokenPair("TästAccess".toCharArray(), "\"TästRefresh\"!@#$%^&*()-_=+{}[]:;\"'<>,.?/\\~`".toCharArray());
+        boolean success = underTest.add(key, tokenPair);
+        assertTrue("Storing token pair failed", success);
+
+        final StoredTokenPair readTokenPair = underTest.get(key);
+
+        assertNotNull("Token pair not found", readTokenPair);
+        assertArrayEquals("Retrieved TokenPair.AccessToken is different", "TästAccess".toCharArray(), readTokenPair.getAccessToken().getValue());
+        assertArrayEquals("Retrieved TokenPair.RefreshToken is different", "\"TästRefresh\"!@#$%^&*()-_=+{}[]:;\"'<>,.?/\\~`".toCharArray(), readTokenPair.getRefreshToken().getValue());
     }
 }

--- a/src/test/java/com/microsoft/credentialstorage/implementation/macosx/KeychainSecurityBackedTokenStoreIT.java
+++ b/src/test/java/com/microsoft/credentialstorage/implementation/macosx/KeychainSecurityBackedTokenStoreIT.java
@@ -77,4 +77,18 @@ public class KeychainSecurityBackedTokenStoreIT {
         StoredToken nonExistentToken = underTest.get(key);
         assertNull(nonExistentToken);
     }
+
+    @Test
+    public void get_shouldHandleNonAsciiAndSpecialValues() {
+        final String key = "KeychainTest:http://test.com:Token";
+
+        StoredToken tokenPair = new StoredToken("\"TästAccess\"!@#$%^&*()-_=+{}[]:;\"'<>,.?/\\~`".toCharArray(), StoredTokenType.ACCESS);
+        boolean success = underTest.add(key, tokenPair);
+        assertTrue("Storing token pair failed", success);
+
+        final StoredToken readToken = underTest.get(key);
+
+        assertNotNull("Token not found", readToken);
+        assertArrayEquals("Retrieved Token is different", "\"TästAccess\"!@#$%^&*()-_=+{}[]:;\"'<>,.?/\\~`".toCharArray(), readToken.getValue());
+    }
 }


### PR DESCRIPTION
Resolves #9 

macOs keychain CLI returns non-ascii values as Hex value + escaped string. The change converts the hex value to UTF-8 Java string to handle properly non-ascii user / password values in credentials.

Special characters are now also supported for password values.